### PR TITLE
Update project branding and metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,8 +17,8 @@ export const viewport: Viewport = {
   themeColor: '#000000',
 };
 export const metadata: Metadata = {
-  title: 'n0ch4t Stater Kit',
-  description: 'Next.js Starter Kit - n0ch4t',
+  title: 'c0zyCr473 Stater Kit',
+  description: 'Next.js Starter Kit - c0zyCr473',
   manifest: '/manifest.webmanifest',
   icons: {
     other: [

--- a/layout/BaseLayout/Header/Header.tsx
+++ b/layout/BaseLayout/Header/Header.tsx
@@ -21,7 +21,7 @@ export async function Header() {
           </span>
         </div>
         <div className={styles['right']}>
-          <Link href={'https://github.com/devsepnine'}>
+          <Link href={'https://github.com/devsepnine/nextjs-starter'}>
             <Button variant={'ghost'} size={'icon'} aria-label={'github'}>
               <Icon icon={'mingcute:github-fill'} width={15} height={15} />
             </Button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starter-pack",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,9 +4,9 @@
   "display": "standalone",
   "scope": "/",
   "start_url": "/",
-  "name": "n0ch4t",
-  "short_name": "n0ch4t",
-  "description": "n0ch4t starter",
+  "name": "c0zyCr473",
+  "short_name": "c0zyCr473",
+  "description": "c0zyCr473 starter",
   "icons": [
     {
       "src": "/assets/pwa-icons/icon-192x192.png",


### PR DESCRIPTION
Updated app name, descriptions, and links to reflect the new branding as "c0zyCr473." Adjusted the GitHub link in the header to point to the updated repository. These changes ensure consistency across the manifest, metadata, and UI.